### PR TITLE
fix: remove comma from the example configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ jobs:
       with:
         ghToken: ${{ secrets.GITHUB_TOKEN }}
         eslintFiles: "lib, scripts"
-        eslintConfig: "myConfigs/eslint.config.js",
+        eslintConfig: "myConfigs/eslint.config.js"
         eslintExt: "ts, tsx"
 ```
 


### PR DESCRIPTION
There's an unnecessary comma in the example configuration.